### PR TITLE
Changes pex_rtmp_server_dialin/out to return client ID

### DIFF
--- a/plugins/pexrtmpserversink.c
+++ b/plugins/pexrtmpserversink.c
@@ -134,9 +134,9 @@ pex_rtmp_server_sink_start (GstBaseSink * basesink)
     /* create a path to use between sink and server */
     sink->path = g_strdup ("pexpath");
 
-    gboolean ret = pex_rtmp_server_dialout (sink->server,
+    gint ret = pex_rtmp_server_dialout (sink->server,
         sink->path, sink->dialout_url, NULL, 23000);
-    if (!ret) {
+    if (ret == -1) {
       GST_ERROR_OBJECT (sink, "Could not dial out to %s", sink->dialout_url);
       return FALSE;
     }

--- a/plugins/pexrtmpserversink.c
+++ b/plugins/pexrtmpserversink.c
@@ -136,7 +136,7 @@ pex_rtmp_server_sink_start (GstBaseSink * basesink)
 
     gint ret = pex_rtmp_server_dialout (sink->server,
         sink->path, sink->dialout_url, NULL, 23000);
-    if (ret == -1) {
+    if (ret == CLIENT_ID_FAILURE) {
       GST_ERROR_OBJECT (sink, "Could not dial out to %s", sink->dialout_url);
       return FALSE;
     }

--- a/plugins/pexrtmpserversrc.c
+++ b/plugins/pexrtmpserversrc.c
@@ -121,9 +121,9 @@ pex_rtmp_server_src_start (GstBaseSrc * basesrc)
     /* create a path to use between src and server */
     src->path = g_strdup ("pexpath");
 
-    gboolean ret = pex_rtmp_server_dialin (src->server,
+    gint ret = pex_rtmp_server_dialin (src->server,
         src->path, src->dialin_url, NULL, 22000);
-    if (!ret) {
+    if (ret == -1) {
       GST_ERROR_OBJECT (src, "Could not dial out to %s", src->dialin_url);
       return FALSE;
     }

--- a/plugins/pexrtmpserversrc.c
+++ b/plugins/pexrtmpserversrc.c
@@ -123,7 +123,7 @@ pex_rtmp_server_src_start (GstBaseSrc * basesrc)
 
     gint ret = pex_rtmp_server_dialin (src->server,
         src->path, src->dialin_url, NULL, 22000);
-    if (ret == -1) {
+    if (ret == CLIENT_ID_FAILURE) {
       GST_ERROR_OBJECT (src, "Could not dial out to %s", src->dialin_url);
       return FALSE;
     }

--- a/src/pexrtmpserver.c
+++ b/src/pexrtmpserver.c
@@ -50,8 +50,6 @@ GST_DEBUG_CATEGORY (pex_rtmp_server_debug);
 #define DEFAULT_CHUNK_SIZE 128
 #define DEFAULT_TCP_SYNCNT -1
 
-#define CLIENT_ID_FAILURE -1
-
 enum
 {
   PROP_0,
@@ -179,9 +177,7 @@ rtmp_server_add_client_by_id (PexRtmpServer * srv, Client * client)
   g_hash_table_insert (srv->client_by_id,
       GINT_TO_POINTER (srv->client_id), client);
   srv->client_id++;
-  if (srv->client_id == CLIENT_ID_FAILURE){
-    srv->client_id++;
-  }
+  g_assert (srv->client_id != CLIENT_ID_FAILURE);
   g_mutex_unlock (&srv->client_by_id_lock);
 }
 
@@ -576,7 +572,7 @@ pex_rtmp_server_external_connect (PexRtmpServer * srv,
     const gchar * src_path, const gchar * url, const gchar * addresses,
     const gboolean is_publisher, gint src_port)
 {
-  gint ret = -1;
+  gint ret = CLIENT_ID_FAILURE;
 
   GST_DEBUG_OBJECT (srv, "Initiating an outgoing connection");
 

--- a/src/pexrtmpserver.h
+++ b/src/pexrtmpserver.h
@@ -46,15 +46,15 @@ PEX_RTMPSERVER_EXPORT
 gchar * pex_rtmp_server_get_application_for_path (PexRtmpServer * srv,
     gchar * path, gboolean is_publisher);
 PEX_RTMPSERVER_EXPORT
-gboolean pex_rtmp_server_dialout (PexRtmpServer * self,
+gint pex_rtmp_server_dialout (PexRtmpServer * self,
     const gchar * path, const gchar * url, const gchar * addresses,
     gint src_port);
 PEX_RTMPSERVER_EXPORT
-gboolean pex_rtmp_server_dialin (PexRtmpServer * self,
+gint pex_rtmp_server_dialin (PexRtmpServer * self,
     const gchar * path, const gchar * url, const gchar * addresses,
     gint src_port);
 PEX_RTMPSERVER_EXPORT
-gboolean pex_rtmp_server_external_connect (PexRtmpServer * self,
+gint pex_rtmp_server_external_connect (PexRtmpServer * self,
     const gchar * path, const gchar * url, const gchar * addresses,
     const gboolean is_publisher, gint src_port);
 

--- a/src/pexrtmpserver.h
+++ b/src/pexrtmpserver.h
@@ -27,6 +27,8 @@ G_DECLARE_FINAL_TYPE (PexRtmpServer, pex_rtmp_server, PEX, RTMP_SERVER, GObject)
 #define PEX_TYPE_RTMP_SERVER (pex_rtmp_server_get_type ())
 #define PEX_RTMP_SERVER_CAST(obj) ((PexRtmpServer *)(obj))
 
+#define CLIENT_ID_FAILURE -1
+
 PEX_RTMPSERVER_EXPORT
 PexRtmpServer * pex_rtmp_server_new (const gchar * application_name,
     gint port, gint ssl_port,

--- a/tests/rtmpharness.c
+++ b/tests/rtmpharness.c
@@ -666,7 +666,7 @@ rtmp_harness_wait_for_notified_subscribers (RTMPHarness * h, gint subscribers)
     g_usleep (G_USEC_PER_SEC / 100);
 }
 
-gboolean
+gint
 rtmp_harness_dialout (RTMPHarness * h_from, gint id_from,
     RTMPHarness * h_to, gint id_to, const gchar * protocol,
     const gchar * host, const gchar * ip)
@@ -683,14 +683,14 @@ rtmp_harness_dialout (RTMPHarness * h_from, gint id_from,
   gchar * publisher_url = rtmp_harness_get_publisher_url (h_to,
     s_to->path, protocol, port, host);
 
-  gboolean result = pex_rtmp_server_dialout (h_from->server, p_from->path, publisher_url, ip, 0);
+  gint result = pex_rtmp_server_dialout (h_from->server, p_from->path, publisher_url, ip, 0);
 
   g_free (publisher_url);
 
   return result;
 }
 
-gboolean
+gint
 rtmp_harness_dialin (RTMPHarness * h_from, gint id_from,
     RTMPHarness * h_to, gint id_to, const gchar * protocol,
     const gchar * host, const gchar * ip)
@@ -707,7 +707,7 @@ rtmp_harness_dialin (RTMPHarness * h_from, gint id_from,
   gchar * publisher_url = rtmp_harness_get_publisher_url (h_to,
     p_to->path, protocol, port, host);
 
-  gboolean result = pex_rtmp_server_dialin (h_from->server, s_from->path, publisher_url, ip, 0);
+  gint result = pex_rtmp_server_dialin (h_from->server, s_from->path, publisher_url, ip, 0);
 
   g_free (publisher_url);
 


### PR DESCRIPTION
Changes pex_rtmp_server_dialin/out to return the client ID of the created client for easier bookkeeping in infinity.