### PR TITLE
pmxrtmp: Add function to set the client->path, for handling clients t…

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -811,7 +811,7 @@ client_handle_publish (Client * client, gint txid, AmfDec * dec)
       "level", G_TYPE_STRING, "status",
       "code", G_TYPE_STRING, "NetStream.Publish.Start",
       "description", G_TYPE_STRING, "Stream is now published.",
-      "details", G_TYPE_STRING, path,
+      "details", G_TYPE_STRING, client->path,
       NULL);
   ret = client_send_onstatus_message (client, status, CHUNK_STREAM_ID_RESULT);
   if (ret != PEX_RTMP_SERVER_STATUS_OK)
@@ -2099,6 +2099,7 @@ client_new (GObject * server,
 static void
 client_free (Client * client)
 {
+  g_free (client->orig_path);
   g_free (client->path);
   g_free (client->url);
   g_free (client->addresses);

--- a/src/client.h
+++ b/src/client.h
@@ -91,6 +91,7 @@ struct _Client
   gint port;
   gchar *remote_host;
 
+  gchar *orig_path;
   gchar *path;
   gchar *dialout_path;
   gchar *url;

--- a/src/pexrtmpserver.h
+++ b/src/pexrtmpserver.h
@@ -29,6 +29,8 @@ G_DECLARE_FINAL_TYPE (PexRtmpServer, pex_rtmp_server, PEX, RTMP_SERVER, GObject)
 
 #define CLIENT_ID_FAILURE -1
 
+typedef void (*PmxRtmpServerUpdateClientPath) (const char * base_path, gpointer user_context);
+
 PEX_RTMPSERVER_EXPORT
 PexRtmpServer * pex_rtmp_server_new (const gchar * application_name,
     gint port, gint ssl_port,


### PR DESCRIPTION
…hat use query parameters, and need to update the path so it matches that of the play stream. This function in turn, is sent as a parameter in the SIGNAL_ON_PUBLISH signal.