### PR TITLE
pexrtmpserver: allow binding on port 0

### DIFF
--- a/src/pexrtmpserver.c
+++ b/src/pexrtmpserver.c
@@ -1293,3 +1293,21 @@ pex_rtmp_server_class_init (PexRtmpServerClass * klass)
   GST_DEBUG_CATEGORY_INIT (pex_rtmp_server_debug, "pexrtmpserver", 0,
       "pexrtmpserver");
 }
+
+gint pex_rtmp_server_get_port(const PexRtmpServer * srv)
+{
+  gint port;
+  if (tcp_get_listen_port(srv->listen_fd, &port) == 0) {
+    return port;
+  }
+  return -1;
+}
+
+gint pex_rtmp_server_get_ssl_port(const PexRtmpServer * srv)
+{
+  gint port;
+  if (tcp_get_listen_port(srv->listen_ssl_fd, &port) == 0) {
+    return port;
+  }
+  return -1;
+}

--- a/src/pexrtmpserver.c
+++ b/src/pexrtmpserver.c
@@ -743,11 +743,11 @@ rtmp_server_do_poll (PexRtmpServer * srv)
   }
 
   /* check for new connections */
-  if (srv->port >= 0 && gst_poll_fd_can_read (srv->fd_set, &srv->listen_gfd)) {
+  if (srv->port > INVALID_PORT && gst_poll_fd_can_read (srv->fd_set, &srv->listen_gfd)) {
     rtmp_server_create_client (srv, srv->listen_gfd.fd);
     return TRUE;
   }
-  if (srv->ssl_port >= 0 && gst_poll_fd_can_read (srv->fd_set, &srv->listen_ssl_gfd)) {
+  if (srv->ssl_port > INVALID_PORT && gst_poll_fd_can_read (srv->fd_set, &srv->listen_ssl_gfd)) {
     rtmp_server_create_client (srv, srv->listen_ssl_gfd.fd);
     return TRUE;
   }
@@ -860,7 +860,7 @@ gboolean
 pex_rtmp_server_start (PexRtmpServer * srv)
 {
   /* listen for normal and ssl connections */
-  if (srv->port >= 0) {
+  if (srv->port > INVALID_PORT) {
     srv->listen_fd = tcp_listen (srv->port);
     if (srv->listen_fd <= 0) {
       GST_ERROR_OBJECT (srv, "Could not listen on port %d", srv->port);
@@ -872,7 +872,7 @@ pex_rtmp_server_start (PexRtmpServer * srv)
     gst_poll_fd_ctl_read (srv->fd_set, &srv->listen_gfd, TRUE);
   }
 
-  if (srv->ssl_port >= 0) {
+  if (srv->ssl_port > INVALID_PORT) {
 #ifdef HAVE_OPENSSL
     srv->listen_ssl_fd = tcp_listen (srv->ssl_port);
     if (srv->listen_ssl_fd <= 0) {
@@ -1187,12 +1187,12 @@ pex_rtmp_server_class_init (PexRtmpServerClass * klass)
 
   g_object_class_install_property (gobject_class, PROP_PORT,
       g_param_spec_int ("port", "Port",
-          "The port to listen on", -1, 65535, DEFAULT_PORT,
+          "The port to listen on", INVALID_PORT, MAX_PORT, DEFAULT_PORT,
           G_PARAM_CONSTRUCT | G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_SSL_PORT,
       g_param_spec_int ("ssl-port", "Port",
-          "The port to listen on", -1, 65535, DEFAULT_SSL_PORT,
+          "The port to listen on", INVALID_PORT, MAX_PORT, DEFAULT_SSL_PORT,
           G_PARAM_CONSTRUCT | G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_CERT_FILE,
@@ -1300,7 +1300,7 @@ gint pex_rtmp_server_get_port(const PexRtmpServer * srv)
   if (tcp_get_listen_port(srv->listen_fd, &port) == 0) {
     return port;
   }
-  return -1;
+  return INVALID_PORT;
 }
 
 gint pex_rtmp_server_get_ssl_port(const PexRtmpServer * srv)
@@ -1309,5 +1309,5 @@ gint pex_rtmp_server_get_ssl_port(const PexRtmpServer * srv)
   if (tcp_get_listen_port(srv->listen_ssl_fd, &port) == 0) {
     return port;
   }
-  return -1;
+  return INVALID_PORT;
 }

--- a/src/pexrtmpserver.c
+++ b/src/pexrtmpserver.c
@@ -1298,18 +1298,14 @@ pex_rtmp_server_class_init (PexRtmpServerClass * klass)
 
 gint pex_rtmp_server_get_port(const PexRtmpServer * srv)
 {
-  gint port;
-  if (tcp_get_listen_port(srv->listen_fd, &port) == 0) {
-    return port;
-  }
-  return INVALID_PORT;
+  gint port = INVALID_PORT;
+  tcp_get_listen_port (srv->listen_fd, &port);
+  return port;
 }
 
 gint pex_rtmp_server_get_ssl_port(const PexRtmpServer * srv)
 {
-  gint port;
-  if (tcp_get_listen_port(srv->listen_ssl_fd, &port) == 0) {
-    return port;
-  }
-  return INVALID_PORT;
+  gint port = INVALID_PORT;
+  tcp_get_listen_port (srv->listen_ssl_fd, &port);
+  return port;
 }

--- a/src/pexrtmpserver.c
+++ b/src/pexrtmpserver.c
@@ -743,11 +743,11 @@ rtmp_server_do_poll (PexRtmpServer * srv)
   }
 
   /* check for new connections */
-  if (srv->port && gst_poll_fd_can_read (srv->fd_set, &srv->listen_gfd)) {
+  if (srv->port >= 0 && gst_poll_fd_can_read (srv->fd_set, &srv->listen_gfd)) {
     rtmp_server_create_client (srv, srv->listen_gfd.fd);
     return TRUE;
   }
-  if (srv->ssl_port && gst_poll_fd_can_read (srv->fd_set, &srv->listen_ssl_gfd)) {
+  if (srv->ssl_port >= 0 && gst_poll_fd_can_read (srv->fd_set, &srv->listen_ssl_gfd)) {
     rtmp_server_create_client (srv, srv->listen_ssl_gfd.fd);
     return TRUE;
   }
@@ -860,7 +860,7 @@ gboolean
 pex_rtmp_server_start (PexRtmpServer * srv)
 {
   /* listen for normal and ssl connections */
-  if (srv->port) {
+  if (srv->port >= 0) {
     srv->listen_fd = tcp_listen (srv->port);
     if (srv->listen_fd <= 0) {
       GST_ERROR_OBJECT (srv, "Could not listen on port %d", srv->port);
@@ -872,7 +872,7 @@ pex_rtmp_server_start (PexRtmpServer * srv)
     gst_poll_fd_ctl_read (srv->fd_set, &srv->listen_gfd, TRUE);
   }
 
-  if (srv->ssl_port) {
+  if (srv->ssl_port >= 0) {
 #ifdef HAVE_OPENSSL
     srv->listen_ssl_fd = tcp_listen (srv->ssl_port);
     if (srv->listen_ssl_fd <= 0) {
@@ -1187,12 +1187,12 @@ pex_rtmp_server_class_init (PexRtmpServerClass * klass)
 
   g_object_class_install_property (gobject_class, PROP_PORT,
       g_param_spec_int ("port", "Port",
-          "The port to listen on", 0, 65535, DEFAULT_PORT,
+          "The port to listen on", -1, 65535, DEFAULT_PORT,
           G_PARAM_CONSTRUCT | G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_SSL_PORT,
       g_param_spec_int ("ssl-port", "Port",
-          "The port to listen on", 0, 65535, DEFAULT_SSL_PORT,
+          "The port to listen on", -1, 65535, DEFAULT_SSL_PORT,
           G_PARAM_CONSTRUCT | G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_CERT_FILE,

--- a/src/pexrtmpserver.c
+++ b/src/pexrtmpserver.c
@@ -36,9 +36,11 @@
 GST_DEBUG_CATEGORY (pex_rtmp_server_debug);
 #define GST_CAT_DEFAULT pex_rtmp_server_debug
 
-#define DEFAULT_APPLICATION_NAME ""
+#define MAX_PORT G_MAXUINT16
 #define DEFAULT_PORT 1935
 #define DEFAULT_SSL_PORT 443
+
+#define DEFAULT_APPLICATION_NAME ""
 #define DEFAULT_CERT_FILE ""
 #define DEFAULT_KEY_FILE ""
 #define DEFAULT_TLS1_ENABLED FALSE

--- a/src/pexrtmpserver.c
+++ b/src/pexrtmpserver.c
@@ -1296,14 +1296,14 @@ pex_rtmp_server_class_init (PexRtmpServerClass * klass)
       "pexrtmpserver");
 }
 
-gint pex_rtmp_server_get_port(const PexRtmpServer * srv)
+gint pex_rtmp_server_get_port (const PexRtmpServer * srv)
 {
   gint port = INVALID_PORT;
   tcp_get_listen_port (srv->listen_fd, &port);
   return port;
 }
 
-gint pex_rtmp_server_get_ssl_port(const PexRtmpServer * srv)
+gint pex_rtmp_server_get_ssl_port (const PexRtmpServer * srv)
 {
   gint port = INVALID_PORT;
   tcp_get_listen_port (srv->listen_ssl_fd, &port);

--- a/src/pexrtmpserver.c
+++ b/src/pexrtmpserver.c
@@ -980,6 +980,8 @@ pex_rtmp_server_init (PexRtmpServer * srv)
   srv->thread = NULL;
 
   srv->fd_set = gst_poll_new (TRUE);
+  srv->listen_fd = INVALID_FD;
+  srv->listen_ssl_fd = INVALID_FD;
 
   srv->connections = connections_new ();
   srv->pending_clients = gst_atomic_queue_new (0);

--- a/src/pexrtmpserver.h
+++ b/src/pexrtmpserver.h
@@ -99,10 +99,10 @@ PEX_RTMPSERVER_EXPORT
 void pex_rtmp_server_flush_subscribe (PexRtmpServer * srv, const gchar * path);
 
 PEX_RTMPSERVER_EXPORT
-gint pex_rtmp_server_get_port(const PexRtmpServer * srv);
+gint pex_rtmp_server_get_port (const PexRtmpServer * srv);
 
 PEX_RTMPSERVER_EXPORT
-gint pex_rtmp_server_get_ssl_port(const PexRtmpServer * srv);
+gint pex_rtmp_server_get_ssl_port (const PexRtmpServer * srv);
 
 
 #endif /* __PEX_RTMP_SERVER_H__ */

--- a/src/pexrtmpserver.h
+++ b/src/pexrtmpserver.h
@@ -98,6 +98,11 @@ gboolean pex_rtmp_server_subscribe_flv (PexRtmpServer * srv, const gchar * path,
 PEX_RTMPSERVER_EXPORT
 void pex_rtmp_server_flush_subscribe (PexRtmpServer * srv, const gchar * path);
 
+PEX_RTMPSERVER_EXPORT
+gint pex_rtmp_server_get_port(const PexRtmpServer * srv);
+
+PEX_RTMPSERVER_EXPORT
+gint pex_rtmp_server_get_ssl_port(const PexRtmpServer * srv);
 
 
 #endif /* __PEX_RTMP_SERVER_H__ */

--- a/tests/rtmp.c
+++ b/tests/rtmp.c
@@ -1147,6 +1147,94 @@ GST_START_TEST(rtmp_window_size)
 }
 GST_END_TEST;
 
+GST_START_TEST(rtmp_server_get_port_dynamic)
+{
+  /* port=0 asks the kernel to pick a free port; ssl_port=-1 means "don't listen on SSL" */
+  PexRtmpServer * server = pex_rtmp_server_new ("pexip",
+      0, -1, NULL, NULL, NULL, NULL, NULL, FALSE, FALSE);
+  fail_unless (pex_rtmp_server_start (server));
+
+  /* the kernel should have assigned a real, non-zero port */
+  gint port = pex_rtmp_server_get_port (server);
+  fail_if (port == INVALID_PORT);
+  fail_if (port == 0);
+  fail_unless (port > 0 && port <= G_MAXUINT16);
+
+  /* SSL was disabled (-1), so we should get INVALID_PORT back */
+  fail_unless_equals_int (INVALID_PORT, pex_rtmp_server_get_ssl_port (server));
+
+  pex_rtmp_server_stop (server);
+  pex_rtmp_server_free (server);
+}
+GST_END_TEST;
+
+GST_START_TEST(rtmp_server_get_ssl_port_dynamic)
+{
+  /* mirror of the above, but for the SSL listener */
+  PexRtmpServer * server = pex_rtmp_server_new ("pexip",
+      -1, 0, NULL, NULL, NULL, NULL, NULL, FALSE, FALSE);
+  fail_unless (pex_rtmp_server_start (server));
+
+  gint ssl_port = pex_rtmp_server_get_ssl_port (server);
+  fail_if (ssl_port == INVALID_PORT);
+  fail_if (ssl_port == 0);
+  fail_unless (ssl_port > 0 && ssl_port <= G_MAXUINT16);
+
+  fail_unless_equals_int (INVALID_PORT, pex_rtmp_server_get_port (server));
+
+  pex_rtmp_server_stop (server);
+  pex_rtmp_server_free (server);
+}
+GST_END_TEST;
+
+GST_START_TEST(rtmp_server_get_port_dynamic_both)
+{
+  /* both listeners on dynamic ports - they must end up different */
+  PexRtmpServer * server = pex_rtmp_server_new ("pexip",
+      0, 0, NULL, NULL, NULL, NULL, NULL, FALSE, FALSE);
+  fail_unless (pex_rtmp_server_start (server));
+
+  gint port = pex_rtmp_server_get_port (server);
+  gint ssl_port = pex_rtmp_server_get_ssl_port (server);
+
+  fail_if (port == INVALID_PORT);
+  fail_if (ssl_port == INVALID_PORT);
+  fail_if (port == ssl_port);
+
+  pex_rtmp_server_stop (server);
+  pex_rtmp_server_free (server);
+}
+GST_END_TEST;
+
+GST_START_TEST(rtmp_server_get_port_unset)
+{
+  /* -1 means "no listener" for both - getters should report INVALID_PORT */
+  PexRtmpServer * server = pex_rtmp_server_new ("pexip",
+      -1, -1, NULL, NULL, NULL, NULL, NULL, FALSE, FALSE);
+  fail_unless (pex_rtmp_server_start (server));
+
+  fail_unless_equals_int (INVALID_PORT, pex_rtmp_server_get_port (server));
+  fail_unless_equals_int (INVALID_PORT, pex_rtmp_server_get_ssl_port (server));
+
+  pex_rtmp_server_stop (server);
+  pex_rtmp_server_free (server);
+}
+GST_END_TEST;
+
+GST_START_TEST(rtmp_server_get_port_before_start)
+{
+  /* before start() there is no bound socket, so the getters must not crash
+   * and must return INVALID_PORT */
+  PexRtmpServer * server = pex_rtmp_server_new ("pexip",
+      0, 0, NULL, NULL, NULL, NULL, NULL, FALSE, FALSE);
+
+  fail_unless_equals_int (INVALID_PORT, pex_rtmp_server_get_port (server));
+  fail_unless_equals_int (INVALID_PORT, pex_rtmp_server_get_ssl_port (server));
+
+  pex_rtmp_server_free (server);
+}
+GST_END_TEST;
+
 GST_START_TEST(rtmp_server_notifications)
 {
   RTMPHarness * h = rtmp_harness_new ("live");
@@ -1989,9 +2077,14 @@ rtmp_suite (void)
   tcase_add_test (tc_chain, rtmp_amf_dec_fuzzing);
 
   tcase_add_test (tc_chain, rtmp_window_size);
-  (void)rtmp_server_notifications;
-  //tcase_add_test (tc_chain, rtmp_server_notifications);
 
+  tcase_add_test (tc_chain, rtmp_server_get_port_dynamic);
+  tcase_add_test (tc_chain, rtmp_server_get_ssl_port_dynamic);
+  tcase_add_test (tc_chain, rtmp_server_get_port_dynamic_both);
+  tcase_add_test (tc_chain, rtmp_server_get_port_unset);
+  tcase_add_test (tc_chain, rtmp_server_get_port_before_start);
+
+  tcase_skip_broken_test (tc_chain, rtmp_server_notifications);
   tcase_add_test (tc_chain, rtmp_server_url_parse);
   tcase_add_test (tc_chain, rtmp_server_dialin);
   tcase_add_test (tc_chain, rtmp_server_dialin_and_dialout);

--- a/tests/rtmp.c
+++ b/tests/rtmp.c
@@ -2039,6 +2039,168 @@ GST_START_TEST(rtmpsink_start_stop_start)
 }
 GST_END_TEST;
 
+GST_START_TEST (rtmp_tcp_get_listen_port_null_port)
+{
+  /* Passing NULL as the out-param is rejected with errno=EINVAL.
+   * fd value is irrelevant - we should bail out before touching it. */
+  errno = 0;
+  fail_if (tcp_get_listen_port (-1, NULL));
+  fail_unless_equals_int (EINVAL, errno);
+}
+
+GST_END_TEST;
+
+GST_START_TEST (rtmp_tcp_get_listen_port_not_a_socket)
+{
+  /* A valid fd that is not a socket -> getsockname returns ENOTSOCK. */
+  gint fd = open ("/dev/null", O_RDONLY);
+  fail_if (fd < 0);
+
+  gint port = 12345;
+  errno = 0;
+  fail_if (tcp_get_listen_port (fd, &port));
+  fail_unless_equals_int (ENOTSOCK, errno);
+  fail_unless_equals_int (12345, port);
+
+  close (fd);
+}
+
+GST_END_TEST;
+
+GST_START_TEST (rtmp_tcp_get_listen_port_unsupported_family)
+{
+  /* A bound UNIX-domain socket has AF_UNIX, which the function explicitly
+   * rejects with EAFNOSUPPORT. This pins the default-branch contract. */
+  gint fd = socket (AF_UNIX, SOCK_STREAM, 0);
+  fail_if (fd < 0);
+
+  /* bind to an autobind abstract address so we don't touch the filesystem
+   * (Linux-specific). On non-Linux, skip this test. */
+#ifdef __linux__
+  struct sockaddr_un addr = { 0 };
+  addr.sun_family = AF_UNIX;
+  /* abstract namespace: leading NUL */
+  fail_if (bind (fd, (struct sockaddr *) &addr, sizeof (sa_family_t)) != 0);
+
+  gint port = 12345;
+  errno = 0;
+  fail_if (tcp_get_listen_port (fd, &port));
+  fail_unless_equals_int (EAFNOSUPPORT, errno);
+  fail_unless_equals_int (12345, port);
+#endif
+
+  close (fd);
+}
+
+GST_END_TEST;
+
+GST_START_TEST (rtmp_tcp_get_listen_port_ipv4)
+{
+  /* Explicit IPv4 path: bind to 127.0.0.1:0 and verify we read back the
+   * kernel-assigned port. */
+  gint fd = socket (AF_INET, SOCK_STREAM, 0);
+  fail_if (fd < 0);
+
+  struct sockaddr_in addr = { 0 };
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
+  addr.sin_port = 0;
+  fail_if (bind (fd, (struct sockaddr *) &addr, sizeof (addr)) != 0);
+
+  gint port = 0;
+  fail_unless (tcp_get_listen_port (fd, &port));
+  fail_if (port == 0);
+  fail_unless (port > 0 && port <= G_MAXUINT16);
+
+  close (fd);
+}
+
+GST_END_TEST;
+
+GST_START_TEST (rtmp_tcp_get_listen_port_ipv6)
+{
+  /* Explicit IPv6 path: this is the bug the sockaddr_storage refactor
+   * actually fixed - sockaddr was too small for sockaddr_in6. */
+  gint fd = socket (AF_INET6, SOCK_STREAM, 0);
+  if (fd < 0)
+    return;                     /* IPv6 not available in this environment - skip */
+
+  struct sockaddr_in6 addr = { 0 };
+  addr.sin6_family = AF_INET6;
+  addr.sin6_addr = in6addr_loopback;
+  addr.sin6_port = 0;
+  fail_if (bind (fd, (struct sockaddr *) &addr, sizeof (addr)) != 0);
+
+  gint port = 0;
+  fail_unless (tcp_get_listen_port (fd, &port));
+  fail_if (port == 0);
+  fail_unless (port > 0 && port <= G_MAXUINT16);
+
+  close (fd);
+}
+
+GST_END_TEST;
+
+GST_START_TEST (rtmp_tcp_get_listen_port_unbound_socket)
+{
+  /* A socket() that has not been bind()ed yet: on Linux this returns
+   * a sockaddr with port 0 and succeeds. The point of this test is to
+   * document the behavior so a future refactor doesn't change it silently. */
+  gint fd = socket (AF_INET, SOCK_STREAM, 0);
+  fail_if (fd < 0);
+
+  gint port = -1;
+  fail_unless (tcp_get_listen_port (fd, &port));
+  fail_unless_equals_int (0, port);
+
+  close (fd);
+}
+
+GST_END_TEST;
+
+GST_START_TEST (rtmp_tcp_get_listen_port_invalid_fd)
+{
+  /* INVALID_FD is the documented "no listener" sentinel. Passing it must be
+   * rejected with EINVAL before any getsockname() call, and must leave the
+   * caller's port value untouched. */
+  gint port = 12345;            /* sentinel */
+  errno = 0;
+  fail_if (tcp_get_listen_port (INVALID_FD, &port));
+  fail_unless_equals_int (EINVAL, errno);
+  fail_unless_equals_int (12345, port);
+}
+
+GST_END_TEST;
+
+GST_START_TEST (rtmp_tcp_get_listen_port_invalid_fd_and_null_port)
+{
+  /* Both inputs invalid: still EINVAL, still no crash. Pins down that the
+   * NULL-port and INVALID_FD checks are combined into a single guard and
+   * neither is dependent on the other. */
+  errno = 0;
+  fail_if (tcp_get_listen_port (INVALID_FD, NULL));
+  fail_unless_equals_int (EINVAL, errno);
+}
+
+GST_END_TEST;
+
+GST_START_TEST (rtmp_tcp_get_listen_port_closed_fd)
+{
+  /* A closed (but not INVALID_FD) descriptor: should reach getsockname()
+   * and fail with EBADF. */
+  gint fd = socket (AF_INET, SOCK_STREAM, 0);
+  fail_if (fd < 0);
+  close (fd);
+
+  gint port = 12345;
+  errno = 0;
+  fail_if (tcp_get_listen_port (fd, &port));
+  fail_unless_equals_int (EBADF, errno);
+  fail_unless_equals_int (12345, port);
+}
+
+GST_END_TEST;
+
 static Suite *
 rtmp_suite (void)
 {
@@ -2114,6 +2276,17 @@ rtmp_suite (void)
   tcase_add_test (tc_chain, rtmp_unlock_sink_bug5054);
   tcase_add_test (tc_chain, rtmp_unlock_src);
   tcase_add_test (tc_chain, rtmpsink_start_stop_start);
+
+  tcase_add_test (tc_chain, rtmp_tcp_get_listen_port_null_port);
+  tcase_add_test (tc_chain, rtmp_tcp_get_listen_port_not_a_socket);
+  tcase_add_test (tc_chain, rtmp_tcp_get_listen_port_unsupported_family);
+  tcase_add_test (tc_chain, rtmp_tcp_get_listen_port_ipv4);
+  tcase_add_test (tc_chain, rtmp_tcp_get_listen_port_ipv6);
+  tcase_add_test (tc_chain, rtmp_tcp_get_listen_port_unbound_socket);
+  tcase_add_test (tc_chain, rtmp_tcp_get_listen_port_invalid_fd);
+  tcase_add_test (tc_chain, rtmp_tcp_get_listen_port_invalid_fd_and_null_port);
+  tcase_add_test (tc_chain, rtmp_tcp_get_listen_port_closed_fd);
+
   return s;
 }
 

--- a/utils/tcp.c
+++ b/utils/tcp.c
@@ -314,10 +314,14 @@ tcp_listen (gint port)
 
   // Get the actual port we are listening on if using a dynamic port
   if (port == DYNAMIC_PORT) {
-    gint listen_port;
-    if (tcp_get_listen_port (fd, &listen_port)) == 0) {
-        port = listen_port;
+    gint listen_port = INVALID_PORT;
+    if (!tcp_get_listen_port (fd, &listen_port)) {
+      GST_WARNING ("Unable to get listen port: %s", strerror (errno));
+      _close_socket (fd);
+      fd = INVALID_FD;
+      goto done;
     }
+    port = listen_port;
   }
   GST_DEBUG ("Listening on port %d with fd %d", port, fd);
 

--- a/utils/tcp.c
+++ b/utils/tcp.c
@@ -307,6 +307,19 @@ tcp_listen (gint port)
   }
 
   listen (fd, 10);
+  // Get the actual port we are listening on if using a dynamic port
+  if (port == 0) {
+    gint listen_port;
+    switch (tcp_get_listen_port(fd, &listen_port)) {
+      case 0:
+        port = listen_port;
+        break;
+      case -1:
+        GST_WARNING ("Unable to get listen port: %s", get_error_msg ());
+      default:
+        break;
+    }
+  }
   GST_DEBUG ("Listening on port %d with fd %d", port, fd);
 
 done:

--- a/utils/tcp.c
+++ b/utils/tcp.c
@@ -372,26 +372,22 @@ gboolean
 tcp_is_localhost (gint fd)
 {
   struct sockaddr_storage addr;
-  struct sockaddr_in6 *sin6;
-  struct sockaddr_in *sin;
   socklen_t len = sizeof (addr);
   gchar ipstr[INET6_ADDRSTRLEN];
-  gboolean is_localhost = FALSE;
 
-  if (getpeername (fd, (struct sockaddr *) &addr, &len) == 0) {
-    if (addr.ss_family == AF_INET) {
-      sin = (struct sockaddr_in *) &addr;
-      inet_ntop (AF_INET, &sin->sin_addr, ipstr, sizeof (ipstr));
-    } else {
-      sin6 = (struct sockaddr_in6 *) &addr;
-      inet_ntop (AF_INET6, &sin6->sin6_addr, ipstr, sizeof ipstr);
-    }
-    is_localhost = g_strcmp0 (ipstr, "::1") == 0 ||
-        g_strcmp0 (ipstr, "::ffff:127.0.0.1") == 0 ||
-        g_strcmp0 (ipstr, "127.0.0.1") == 0;
+  if (getpeername (fd, (struct sockaddr *) &addr, &len) != 0) {
+    return FALSE;
   }
-
-  return is_localhost;
+  switch (addr.ss_family) {
+    case AF_INET:
+      inet_ntop (AF_INET, &((struct sockaddr_in *)&addr)->sin_addr, ipstr, sizeof (ipstr));
+      return g_strcmp0 (ipstr, "127.0.0.1") == 0;
+    case AF_INET6:
+      inet_ntop (AF_INET, &((struct sockaddr_in6 *)&addr)->sin6_addr, ipstr, sizeof (ipstr));
+      return g_strcmp0 (ipstr, "::1") == 0 || g_strcmp0 (ipstr, "::ffff:127.0.0.1") == 0;
+    default:
+      return FALSE;
+  }
 }
 
 gint tcp_get_listen_port (const gint fd, gint *port)

--- a/utils/tcp.c
+++ b/utils/tcp.c
@@ -315,14 +315,8 @@ tcp_listen (gint port)
   // Get the actual port we are listening on if using a dynamic port
   if (port == DYNAMIC_PORT) {
     gint listen_port;
-    switch (tcp_get_listen_port(fd, &listen_port)) {
-      case 0:
+    if (tcp_get_listen_port (fd, &listen_port)) == 0) {
         port = listen_port;
-        break;
-      case -1:
-        GST_WARNING ("Unable to get listen port: %s", get_error_msg ());
-      default:
-        break;
     }
   }
   GST_DEBUG ("Listening on port %d with fd %d", port, fd);
@@ -388,27 +382,27 @@ tcp_is_localhost (gint fd)
   }
 }
 
-gint tcp_get_listen_port (const gint fd, gint *port)
+gboolean
+tcp_get_listen_port (gint fd, gint *port)
 {
   struct sockaddr_storage address;
   socklen_t address_len = sizeof (address);
 
-  const int result = getsockname(fd, (struct sockaddr *)&address, &address_len);
-  if (result != 0) {
-    return result;
+  if (getsockname (fd, (struct sockaddr *) &address, &address_len) != 0) {
+    GST_WARNING ("getsockname failed: %s", strerror (errno));
+    return FALSE;
   }
-  uint16_t listen_port;
+
   switch (address.ss_family) {
     case AF_INET:
-      listen_port = ((struct sockaddr_in *)&address)->sin_port;
-      break;
+      *port = ntohs (((struct sockaddr_in *) &address)->sin_port);
+      return TRUE;
     case AF_INET6:
-      listen_port = ((struct sockaddr_in6 *)&address)->sin6_port;
-      break;
+      *port = ntohs (((struct sockaddr_in6 *) &address)->sin6_port);
+      return TRUE;
     default:
-      GST_WARNING ("Cannot get port for family %d", address.ss_family);
-      return -2;
+      GST_WARNING ("Cannot get port for address family %d", address.ss_family);
+      errno = EAFNOSUPPORT;
+      return FALSE;
   }
-  *port = ntohs(listen_port);
-  return result;
 }

--- a/utils/tcp.c
+++ b/utils/tcp.c
@@ -116,7 +116,7 @@ tcp_getaddrinfo (const gchar * ip, gint port,
   hints.ai_flags = ai_flags;
 
   gchar *port_str = NULL;
-  if (port > 0) {
+  if (port >= 0) {
     port_str = g_strdup_printf ("%d", port);
     hints.ai_flags |= AI_NUMERICSERV;
   }

--- a/utils/tcp.c
+++ b/utils/tcp.c
@@ -389,6 +389,11 @@ tcp_is_localhost (gint fd)
 gboolean
 tcp_get_listen_port (gint fd, gint *port)
 {
+  if (G_UNLIKELY (!port)) {
+    errno = EINVAL;
+    return FALSE;
+  }
+
   struct sockaddr_storage address;
   socklen_t address_len = sizeof (address);
 

--- a/utils/tcp.c
+++ b/utils/tcp.c
@@ -299,23 +299,21 @@ tcp_listen (gint port)
     GST_WARNING ("Could not turn off IPV6_V6ONLY: %s", get_error_msg ());
 
   if (bind (fd, result->ai_addr, (int)result->ai_addrlen) < 0) {
-    GST_WARNING ("Unable to listen to port %d: %s",
-        port, strerror (errno));
+    GST_WARNING ("Unable to bind to port %d: %s", port, strerror (errno));
     _close_socket (fd);
     fd = INVALID_FD;
     goto done;
   }
 
   if (listen (fd, 10) != 0) {
-    GST_WARNING ("Unable to listen to port %d: %s",
-        port, strerror (errno));
+    GST_WARNING ("Unable to listen to port %d: %s", port, strerror (errno));
     _close_socket (fd);
     fd = INVALID_FD;
     goto done;
   }
 
   // Get the actual port we are listening on if using a dynamic port
-  if (port == 0) {
+  if (port == DYNAMIC_PORT) {
     gint listen_port;
     switch (tcp_get_listen_port(fd, &listen_port)) {
       case 0:

--- a/utils/tcp.c
+++ b/utils/tcp.c
@@ -306,7 +306,14 @@ tcp_listen (gint port)
     goto done;
   }
 
-  listen (fd, 10);
+  if (listen (fd, 10) != 0) {
+    GST_WARNING ("Unable to listen to port %d: %s",
+        port, strerror (errno));
+    _close_socket (fd);
+    fd = INVALID_FD;
+    goto done;
+  }
+
   // Get the actual port we are listening on if using a dynamic port
   if (port == 0) {
     gint listen_port;

--- a/utils/tcp.c
+++ b/utils/tcp.c
@@ -373,3 +373,28 @@ tcp_is_localhost (gint fd)
 
   return is_localhost;
 }
+
+gint tcp_get_listen_port (const gint fd, gint *port)
+{
+  struct sockaddr_storage address;
+  socklen_t address_len = sizeof (address);
+
+  const int result = getsockname(fd, (struct sockaddr *)&address, &address_len);
+  if (result != 0) {
+    return result;
+  }
+  uint16_t listen_port;
+  switch (address.ss_family) {
+    case AF_INET:
+      listen_port = ((struct sockaddr_in *)&address)->sin_port;
+      break;
+    case AF_INET6:
+      listen_port = ((struct sockaddr_in6 *)&address)->sin6_port;
+      break;
+    default:
+      GST_WARNING ("Cannot get port for family %d", address.ss_family);
+      return -2;
+  }
+  *port = ntohs(listen_port);
+  return result;
+}

--- a/utils/tcp.c
+++ b/utils/tcp.c
@@ -389,7 +389,7 @@ tcp_is_localhost (gint fd)
 gboolean
 tcp_get_listen_port (gint fd, gint *port)
 {
-  if (G_UNLIKELY (!port)) {
+  if (G_UNLIKELY (!port || fd == INVALID_FD)) {
     errno = EINVAL;
     return FALSE;
   }

--- a/utils/tcp.h
+++ b/utils/tcp.h
@@ -51,6 +51,6 @@ void tcp_set_nonblock (gint fd, gboolean enabled);
 PEX_RTMPSERVER_EXPORT
 gboolean tcp_is_localhost (gint fd);
 PEX_RTMPSERVER_EXPORT
-gint tcp_get_listen_port (gint fd, gint* port);
+gboolean tcp_get_listen_port (gint fd, gint* port);
 
 #endif /* __TCP_H__ */

--- a/utils/tcp.h
+++ b/utils/tcp.h
@@ -32,6 +32,9 @@
 #  define PEX_RTMPSERVER_EXPORT extern
 #endif
 
+#define INVALID_PORT -1
+#define DYNAMIC_PORT 0
+
 #define INVALID_FD -1
 
 PEX_RTMPSERVER_EXPORT

--- a/utils/tcp.h
+++ b/utils/tcp.h
@@ -50,7 +50,7 @@ PEX_RTMPSERVER_EXPORT
 void tcp_set_nonblock (gint fd, gboolean enabled);
 PEX_RTMPSERVER_EXPORT
 gboolean tcp_is_localhost (gint fd);
-
+PEX_RTMPSERVER_EXPORT
 gint tcp_get_listen_port (gint fd, gint* port);
 
 #endif /* __TCP_H__ */

--- a/utils/tcp.h
+++ b/utils/tcp.h
@@ -48,4 +48,6 @@ void tcp_set_nonblock (gint fd, gboolean enabled);
 PEX_RTMPSERVER_EXPORT
 gboolean tcp_is_localhost (gint fd);
 
+gint tcp_get_listen_port(gint fd, gint* port);
+
 #endif /* __TCP_H__ */

--- a/utils/tcp.h
+++ b/utils/tcp.h
@@ -51,6 +51,6 @@ void tcp_set_nonblock (gint fd, gboolean enabled);
 PEX_RTMPSERVER_EXPORT
 gboolean tcp_is_localhost (gint fd);
 
-gint tcp_get_listen_port(gint fd, gint* port);
+gint tcp_get_listen_port (gint fd, gint* port);
 
 #endif /* __TCP_H__ */


### PR DESCRIPTION
Instead of allocating a (potentially in-use) port up-front, allow binding on port 0 and let the kernel assign a free port.
Add new APIs to access the SSL & non-SSL listening ports when the server is running (instead of overwriting the user config).

- **utils/tcp/tcp_getaddrinfo: support port 0**
- **utils/tcp: add tcp_get_listen_port**
- **utils/tcp/tcp_listen: log dynamic port**
- **utils/tcp/tcp_listen: handle/log listen errors**
- **pexrtmpserver: allow listening on port 0**
- **pexrtmpserver: add get(_ssl)_port**
